### PR TITLE
implove: 投稿した際にURLを見えないようにする

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ function doPost(e) {
   
   // ユーザ名からtokenの取得
   var token = getValueFromSheet(user_name, 1);
+  var att = [{ "fallback": "スタンプを送信しました", "image_url": stamp_url }]
   
   // ユーザトークンの取得が成功した場合
   if (token != "") {
@@ -37,8 +38,9 @@ function doPost(e) {
     app.chatDelete(channel_id, e.parameter.timestamp);
   
     // 対応するスタンプURLを投稿
-    var post_info = app.postMessage(channel_id, stamp_url, {
-      as_user: true
+    var post_info = app.postMessage(channel_id, "", {
+      attachments : JSON.stringify(att),
+      as_user: true,
     });
   }
   else {
@@ -50,7 +52,8 @@ function doPost(e) {
     app.chatDelete(channel_id, e.parameter.timestamp);
   
     // 対応するスタンプURLを投稿
-    var post_info = app.postMessage(channel_id, stamp_url, {
+    var post_info = app.postMessage(channel_id, "", {
+      attachments : JSON.stringify(att),
       username: user_name,
       icon_url: icon_url,
     });


### PR DESCRIPTION
## 問題点
URLがスタンプの上にあり，気になる

## 改善方法
SlackのAttachments機能を使うことで，URLの見えないスタンプ化が可能
[Attachment機能について](https://api.slack.com/docs/message-attachments)

## 改善結果

before | after
---- | ----
<img src="https://user-images.githubusercontent.com/15684002/27468908-9a02e0b0-5827-11e7-915a-92a660e990b0.png" width="320"/> | <img src="https://user-images.githubusercontent.com/15684002/27468905-977be616-5827-11e7-9d28-21b1202cfd18.png" width="320"/>

